### PR TITLE
Updated to support 5.2

### DIFF
--- a/BUITween.uplugin
+++ b/BUITween.uplugin
@@ -14,6 +14,7 @@
 	"IsBetaVersion": false,
 	"IsExperimentalVersion": false,
 	"Installed": false,
+	"EngineVersion": "5.2",
 	"Modules": [
 		{
 			"Name": "BUITween",

--- a/Source/BUITween/Private/BUITweenInstance.cpp
+++ b/Source/BUITween/Private/BUITweenInstance.cpp
@@ -25,26 +25,26 @@ void FBUITweenInstance::Begin()
 	}
 
 	// Set all the props to the existng state
-	TranslationProp.OnBegin( pWidget->RenderTransform.Translation );
-	ScaleProp.OnBegin( pWidget->RenderTransform.Scale );
-	RotationProp.OnBegin( pWidget->RenderTransform.Angle );
+	TranslationProp.OnBegin( pWidget->GetRenderTransform().Translation );
+	ScaleProp.OnBegin( pWidget->GetRenderTransform().Scale );
+	RotationProp.OnBegin( pWidget->GetRenderTransform().Angle );
 	OpacityProp.OnBegin( pWidget->GetRenderOpacity() );
 
 	{
 		UUserWidget* UW = Cast<UUserWidget>( pWidget );
 		if ( UW )
 		{
-			ColorProp.OnBegin( UW->ColorAndOpacity );
+			ColorProp.OnBegin( UW->GetColorAndOpacity() );
 		}
 		UImage* UI = Cast<UImage>( pWidget );
 		if ( UI )
 		{
-			ColorProp.OnBegin( UI->ColorAndOpacity );
+			ColorProp.OnBegin( UI->GetColorAndOpacity());
 		}
 		UBorder* Border = Cast<UBorder>( pWidget );
 		if ( Border )
 		{
-			ColorProp.OnBegin( Border->ContentColorAndOpacity );
+			ColorProp.OnBegin( Border->GetContentColorAndOpacity());
 		}
 	}
 
@@ -61,32 +61,32 @@ void FBUITweenInstance::Begin()
 	if ( OverlaySlot )
 	{
 		PaddingProp.OnBegin( FVector4(
-			OverlaySlot->Padding.Left,
-			OverlaySlot->Padding.Top,
-			OverlaySlot->Padding.Bottom,
-			OverlaySlot->Padding.Right ) );
+			OverlaySlot->GetPadding().Left,
+			OverlaySlot->GetPadding().Top,
+			OverlaySlot->GetPadding().Bottom,
+			OverlaySlot->GetPadding().Right ) );
 	}
 	else if ( HorizontalBoxSlot )
 	{
 		PaddingProp.OnBegin( FVector4(
-			HorizontalBoxSlot->Padding.Left,
-			HorizontalBoxSlot->Padding.Top,
-			HorizontalBoxSlot->Padding.Bottom,
-			HorizontalBoxSlot->Padding.Right ) );
+			HorizontalBoxSlot->GetPadding().Left,
+			HorizontalBoxSlot->GetPadding().Top,
+			HorizontalBoxSlot->GetPadding().Bottom,
+			HorizontalBoxSlot->GetPadding().Right ) );
 	}
 	else if ( VerticalBoxSlot )
 	{
 		PaddingProp.OnBegin( FVector4(
-			VerticalBoxSlot->Padding.Left,
-			VerticalBoxSlot->Padding.Top,
-			VerticalBoxSlot->Padding.Bottom,
-			VerticalBoxSlot->Padding.Right ) );
+			VerticalBoxSlot->GetPadding().Left,
+			VerticalBoxSlot->GetPadding().Top,
+			VerticalBoxSlot->GetPadding().Bottom,
+			VerticalBoxSlot->GetPadding().Right ) );
 	}
 
 	USizeBox* SizeBox = Cast<USizeBox>( pWidget );
 	if ( SizeBox )
 	{
-		MaxDesiredHeightProp.OnBegin( SizeBox->MaxDesiredHeight );
+		MaxDesiredHeightProp.OnBegin( SizeBox->GetMaxDesiredHeight() );
 	}
 
 	// Apply the starting conditions, even if we delay
@@ -173,7 +173,7 @@ void FBUITweenInstance::Apply( float EasedAlpha )
 	}
 
 	bool bChangedRenderTransform = false;
-	FWidgetTransform CurrentTransform = Target->RenderTransform;
+	FWidgetTransform CurrentTransform = Target->GetRenderTransform();
 
 	if ( TranslationProp.IsSet() )
 	{

--- a/Source/BUITween/Private/BUITweenWidget.cpp
+++ b/Source/BUITween/Private/BUITweenWidget.cpp
@@ -43,26 +43,26 @@ FWidgetAppearance UBUITweenWidget::GetInitialAppearanceStruct(UWidget* TargetWid
 	// The whole thing is almost the same with BUITweenInstance.cpp,
 	// except we're just getting the initial values.
 
-	FVector2D Translation = TargetWidget->RenderTransform.Translation;
-	float Rotation = TargetWidget->RenderTransform.Angle;
-	FVector2D Scale = TargetWidget->RenderTransform.Translation;
+	FVector2D Translation = TargetWidget->GetRenderTransform().Translation;
+	float Rotation = TargetWidget->GetRenderTransform().Angle;
+	FVector2D Scale = TargetWidget->GetRenderTransform().Translation;
 	float Opacity = TargetWidget->GetRenderOpacity();
 	
 	FLinearColor Color;
 	UUserWidget* UW = Cast<UUserWidget>(TargetWidget);
 	if (UW)
 	{
-		Color = UW->ColorAndOpacity;
+		Color = UW->GetColorAndOpacity();
 	}
 	UImage* UI = Cast<UImage>(TargetWidget);
 	if (UI)
 	{
-		Color = UI->ColorAndOpacity;
+		Color = UI->GetColorAndOpacity();
 	}
 	UBorder* Border = Cast<UBorder>(TargetWidget);
 	if (Border)
 	{
-		Color = Border->ContentColorAndOpacity;
+		Color = Border->GetContentColorAndOpacity();
 	}
 	
 	FVector2D CanvasPosition;
@@ -74,11 +74,11 @@ FWidgetAppearance UBUITweenWidget::GetInitialAppearanceStruct(UWidget* TargetWid
 
 	ESlateVisibility WidgetVisibility = TargetWidget->GetVisibility();
 	
-	float MaxDesiredHeight;
+	float MaxDesiredHeight = 0;
 	USizeBox* SizeBox = Cast<USizeBox>(TargetWidget);
 	if (SizeBox)
 	{
-		MaxDesiredHeight = SizeBox->MaxDesiredHeight;
+		MaxDesiredHeight = SizeBox->GetMaxDesiredHeight();
 	}
 	
 	FMargin WidgetPadding;
@@ -88,28 +88,28 @@ FWidgetAppearance UBUITweenWidget::GetInitialAppearanceStruct(UWidget* TargetWid
 	if (OverlaySlot)
 	{
 		WidgetPadding = FVector4(
-			OverlaySlot->Padding.Left,
-			OverlaySlot->Padding.Top,
-			OverlaySlot->Padding.Bottom,
-			OverlaySlot->Padding.Right);
+			OverlaySlot->GetPadding().Left,
+			OverlaySlot->GetPadding().Top,
+			OverlaySlot->GetPadding().Bottom,
+			OverlaySlot->GetPadding().Right);
 	}
 	else if (HorizontalBoxSlot)
 	{
 		WidgetPadding = FVector4(
-			HorizontalBoxSlot->Padding.Left,
-			HorizontalBoxSlot->Padding.Top,
-			HorizontalBoxSlot->Padding.Bottom,
-			HorizontalBoxSlot->Padding.Right);
+			HorizontalBoxSlot->GetPadding().Left,
+			HorizontalBoxSlot->GetPadding().Top,
+			HorizontalBoxSlot->GetPadding().Bottom,
+			HorizontalBoxSlot->GetPadding().Right);
 	}
 	else if (VerticalBoxSlot)
 	{
 		WidgetPadding = FVector4(
-			VerticalBoxSlot->Padding.Left,
-			VerticalBoxSlot->Padding.Top,
-			VerticalBoxSlot->Padding.Bottom,
-			VerticalBoxSlot->Padding.Right);
+			VerticalBoxSlot->GetPadding().Left,
+			VerticalBoxSlot->GetPadding().Top,
+			VerticalBoxSlot->GetPadding().Bottom,
+			VerticalBoxSlot->GetPadding().Right);
 	}
 
-	return FWidgetAppearance(Translation, Rotation, Scale, Opacity, Color, CanvasPosition, Visibility, MaxDesiredHeight, Padding);
+	return FWidgetAppearance(Translation, Rotation, Scale, Opacity, Color, CanvasPosition, GetVisibility(), MaxDesiredHeight, GetPadding());
 }
 

--- a/Source/BUITween/Public/BUIEasing.h
+++ b/Source/BUITween/Public/BUIEasing.h
@@ -40,7 +40,6 @@ enum class EBUIEasingType : uint8
 struct FBUIEasing
 {
 public:
-	#define TWO_PI          (6.28318530717f)
 
 	static float Ease( EBUIEasingType Type, float time, float duration = 1.0f, float overshootOrAmplitude = 0.1f, float period = 1.0f )
 	{


### PR DESCRIPTION
Updated to support 5.2 in .uplugin
Replace deprecated API calls to clear build warnings 
Delete TWO_PI macro as it is now already defined in UnrealMathUtility.h